### PR TITLE
0.1.1 release does not contain the renaming to knative-monitoring

### DIFF
--- a/install/scripts/knative-openshift-policies.sh
+++ b/install/scripts/knative-openshift-policies.sh
@@ -5,9 +5,9 @@ set -e
 oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
 oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
 oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
-oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n knative-monitoring
-oc adm policy add-scc-to-user anyuid -z node-exporter -n knative-monitoring
-oc adm policy add-scc-to-user anyuid -z prometheus-system -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
 oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
 oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
 oc adm policy add-scc-to-user anyuid -z eventing-controller -n knative-eventing


### PR DESCRIPTION
## Proposed Changes

* renaming to `knative-monitoring` was done _after_ the 0.1.1 release  
* 
* 
